### PR TITLE
Fix Star-galaxy relationship expectation

### DIFF
--- a/test/space-spec.js
+++ b/test/space-spec.js
@@ -70,7 +70,7 @@ describe('Star', () => {
     })
 
     it('should add itself to its galaxy\'s stars array upon instantiation', () => {
-        expect(sol.galaxy.stars.includes(sol));
+        expect(sol.galaxy.stars.includes(sol)).to.be.true;
     })
 
     it('should have an array of planets', () => {


### PR DESCRIPTION
`expect(false)` will always pass. Need to add `to.be.true` to get `expect(false).to.be.true` to fail.